### PR TITLE
Fix confiusing sentence about purge of workflows

### DIFF
--- a/documentation/igrc-platform/purge/index.md
+++ b/documentation/igrc-platform/purge/index.md
@@ -76,7 +76,7 @@ When defining or editing workflow advanced properties, you then will be able to 
 
 ![Workflow Type 4](./images/WorkflowType4.png "Workflow Type 4")
 
-The criteria definition for timeslots having active workflow is done the same way as for standard timeslot criteria, beginning with the selection of workflow type:  
+The criteria definition for timeslots having existing workflow is done the same way as for standard timeslot criteria, beginning with the selection of workflow type:  
 
 ![Workflow Type 5](./images/WorkflowType5.png "Workflow Type 5")
 

--- a/documentation/igrc-platform/purge/index.md
+++ b/documentation/igrc-platform/purge/index.md
@@ -76,8 +76,7 @@ When defining or editing workflow advanced properties, you then will be able to 
 
 ![Workflow Type 4](./images/WorkflowType4.png "Workflow Type 4")
 
-The criteria definition for timeslots having existing workflow is done the same way as for standard timeslot criteria, beginning with the selection of workflow type:  
-
+Here you can define the criteria for timeslots with an existing workflow. Follow the same approach as standard timeslot criteria, starting with choosing the workflow type.
 ![Workflow Type 5](./images/WorkflowType5.png "Workflow Type 5")
 
 And then the retention period:  


### PR DESCRIPTION
This is not only for "timeslots having active workflow", but for timeslot having existing workflow, whatever they are active or not (finished).